### PR TITLE
Fix MIT License typo in footer of index page

### DIFF
--- a/themes/vue/layout/index.ejs
+++ b/themes/vue/layout/index.ejs
@@ -54,7 +54,7 @@
 </div>
 
 <div id="footer">
-  <a href="https://opensource.org/licenses/MIT" href="_blank">MIT License</a> 라이센스를 따릅니다.<br>
+  <a href="https://opensource.org/licenses/MIT" href="_blank">MIT License</a>를 따릅니다.<br>
   Copyright &copy; 2014-<%- new Date().getFullYear() %> Evan You
 </div>
 


### PR DESCRIPTION
origin : `Released under the MIT License`