### PR TITLE
migration guide에 누락된 번역 추가

### DIFF
--- a/src/v2/guide/migration.md
+++ b/src/v2/guide/migration.md
@@ -658,7 +658,7 @@ strings.map(function (str) {
 {% raw %}
 <div class="upgrade-path">
   <h4>업그레이드 방법</h4>
-  <p>코드베이스에서 <a href="https://github.com/vuejs/vue-migration-helper">마이그레이션 도우미</a>를 실행하여<code>v-el</code> and <code>v-ref</code>.</p>
+  <p><code>v-el</code>과 <code>v-ref</code>를 찾기 위해 코드베이스에서 <a href="https://github.com/vuejs/vue-migration-helper">마이그레이션 도우미</a>를 실행하기.</p>
 </div>
 {% endraw %}
 


### PR DESCRIPTION
"Run the migration helper on your codebase to find examples of v-el and v-ref."
"코드베이스에서 마이그레이션 도우미를 실행하여 v-el and v-ref." 

깃허브 마크다운 에디터에 한글 입력이 잘 안돼서 그런지 뒷부분이 조금 누락된 것 같아서 수정했습니다.