### PR TITLE
문맥 수정

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -56,7 +56,7 @@ new Vue({
 
 `span`의 내용은 `rawHtml`로 대체됩니다. 이 때 데이터 바인딩은 무시됩니다. Vue는 문자열 기반 템플릿 엔진이 아니기 때문에 `v-html`을 이용해 템플릿을 사용할 수 없습니다. 이와 달리 컴포넌트는 UI 재사용 및 구성을 위한 기본 단위로 사용하는 것을 추천합니다.
 
-<p class="tip">웹사이트에서 임의의 HTML을 동적으로 렌더링하려면 [XSS 취약점](https://en.wikipedia.org/wiki/Cross-site_scripting)으로 쉽게 이어질 수 있으므로 매우 위험할 가능성이 있습니다. 신뢰할 수 있는 콘텐츠에서는 HTML 보간만 사용하고 사용자가 제공한 콘텐츠에서는 **절대** 사용하면 안됩니다.</p>
+<p class="tip">웹사이트에서 임의의 HTML을 동적으로 렌더링하려면 [XSS 취약점](https://en.wikipedia.org/wiki/Cross-site_scripting)으로 쉽게 이어질 수 있으므로 매우 위험할 가능성이 있습니다. 신뢰할 수 있는 콘텐츠에서만 HTML 보간을 사용하고 사용자가 제공한 콘텐츠에서는 **절대** 사용하면 안됩니다.</p>
 
 Mustaches는 HTML 속성에서 사용할 수 없습니다. 대신 [v-bind 디렉티브](../api/#v-bind)를 사용하세요:
 


### PR DESCRIPTION
신뢰할 수 있는 콘텐츠에서'는' HTML 보간'만' 사용하고 사용자가 제공한 콘텐츠에서는 절대 사용하면 안됩니다.
->신뢰할 수 있는 콘텐츠에서'만' HTML 보간'을' 사용하고 사용자가 제공한 콘텐츠에서는 절대 사용하면 안됩니다