### PR TITLE
약어 제거

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -196,7 +196,7 @@ methods: {
 <div v-on:click.self="doThat">...</div>
 ```
 
-<p class="tip">관련 코드가 동일한 순서로 생성되므로 수식어를 사용할 때 순서를 지정하세요. 다시말해 `@click.prevent.self`를 사용하면 **모든 클릭**을 막을 수 있으며 `@click.self.prevent`는 엘리먼트 자체에 대한 클릭만 방지합니다.</p>
+<p class="tip">관련 코드가 동일한 순서로 생성되므로 수식어를 사용할 때 순서를 지정하세요. 다시말해 `v-on:click.prevent.self`를 사용하면 **모든 클릭**을 막을 수 있으며 `v-on:click.self.prevent`는 엘리먼트 자체에 대한 클릭만 방지합니다.</p>
 
 > 2.1.4에 새로 추가됨
 


### PR DESCRIPTION
HTML이 깨져 보여, 원본과 동일하게 약어 제거