### PR TITLE
오타/중복을 수정하고 부분적으로 번역이 되지 않은 부분을 번역했습니다.

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -7,10 +7,10 @@ order: 6
 
 데이터 바인딩은 엘리먼트의 클래스 목록과 인라인 스타일을 조작하기 위해 일반적으로 사용됩니다. 이 두 속성은 `v-bind`를 사용하여 처리할 수 있습니다. 우리는 표현식으로 최종 문자열을 계산하면 됩니다. 그러나 문자열 연결에 간섭하는 것은 짜증나는 일이며 오류가 발생하기 쉽습니다. 이러한 이유로, Vue는 `class`와 `style`에 `v-bind`를 사용할 때 특별히 향상된 기능을 제공합니다. 표현식은 문자열 이외에 객체 또는 배열을 이용할 수 있습니다.
 
-## Binding HTML Classes
+## HTML 클래스 바인딩하기
 <div class="vueschool"><a href="https://vueschool.io/lessons/vuejs-dynamic-classes?friend=vuejs" target="_blank" rel="sponsored noopener" title="Free Vue.js Dynamic Classes Lesson">Watch a free video lesson on Vue School</a></div>
 
-## HTML 클래스 바인딩하기
+
 
 ### 객체 구문
 

--- a/src/v2/guide/custom-directive.md
+++ b/src/v2/guide/custom-directive.md
@@ -144,9 +144,9 @@ new Vue({
 
 ### 다이나믹 디렉티브 전달인자
 
-Directive arguments can be dynamic. For example, in `v-mydirective:[argument]="value"`, the `argument` can be updated based on data properties in our component instance! This makes our custom directives flexible for use throughout our application.
+디렉티브 인자는 동적일 수 있습니다. 예를 들어, `v-mydirective:[argument]="value"`에서 `argument`는 컴포넌트 인스턴스에 데이터 속성에 기반해서 업데이트 될 수 있습니다! 이는 사용자 정의 디렉티브를 응용프로그램 전반에 걸쳐 유연하게 사용되도록 만듭니다.
 
-Let's say you want to make a custom directive that allows you to pin elements to your page using fixed positioning. We could create a custom directive where the value updates the vertical positioning in pixels, like this:
+고정된 위치를 사용해서 페이지에 엘리먼트를 고정하는 사용자 정의 디렉티브를 만들고 싶다고 가정해봅시다. 우리는 다음과 같이 값이 픽셀의 수직 위치를 업데이트하는 사용자 정의 디렉티브를 만들 수 있을겁니다.
 
 ```html
 <div id="baseexample">
@@ -168,7 +168,7 @@ new Vue({
 })
 ```
 
-This would pin the element 200px from the top of the page. But what happens if we run into a scenario when we need to pin the element from the left, instead of the top? Here's where a dynamic argument that can be updated per component instance comes in very handy:
+이것은 페이지의 맨 위로부터 200px 떨어진 곳에 엘리먼트를 고정시킵니다. 하지만 위쪽이 아니라 왼쪽을 기준으로 엘리먼트를 고정해야 하는 시나리오가 발생하면 어떻게 할까요? 다음의 예에서는 컴포넌트 인스턴스별로 업데이트될 수 있는 동적 인수가 매우 편리합니다.
 
 
 ```html
@@ -197,7 +197,7 @@ new Vue({
 })
 ```
 
-Result:
+결과는 다음과 같습니다.
 
 {% raw %}
 <iframe height="200" style="width: 100%;" class="demo" scrolling="no" title="Dynamic Directive Arguments" src="//codepen.io/team/Vue/embed/rgLLzb/?height=300&theme-id=32763&default-tab=result" frameborder="no" allowtransparency="true" allowfullscreen="true">
@@ -206,7 +206,7 @@ Result:
 </iframe>
 {% endraw %}
 
-Our custom directive is now flexible enough to support a few different use cases.
+이 사용자 정의 디렉티브는 이제 몇 가지 다른 사례를 충분히 유연하게 지원할 수 있습니다.
 
 ## 함수 약어
 

--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -210,16 +210,16 @@ methods: {
 
 > 2.3.0+ 이후 추가됨
 
-Vue also offers the `.passive` modifier, corresponding to [`addEventListener`'s `passive` option](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Parameters).
+추가로, Vue는 [`addEventListener`의 `passive` 옵션](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Parameters)에 대응되는 `.passive` 수식어를 제공합니다.
 
 ``` html
-<!-- 스크롤의 기본 이벤트를 취소할 수 없습니다. -->
+<!-- 스크롤의 기본 동작을 취소할 수 없습니다. -->
 <div v-on:scroll.passive="onScroll">...</div>
 ```
 
-추가로, Vue는 `.passive` 수식어를 제공합니다. 특히 모바일 환경에서 성능향상에 도움이 됩니다. 예를 들어, 브라우저는 핸들러가 `event.preventDefault()`를 호출할지 알지 못하므로 프로세스가 완료된 후 스크롤 합니다. `.passive` 수식어는 이 이벤트가 기본 동작을 멈추지 않는다는 것을 브라우저에 알릴 수 있습니다.
+이 수식어는 특히 모바일 환경에서 성능향상에 도움이 됩니다. 예를 들어, 브라우저는 핸들러가 `event.preventDefault()`를 호출할지 알지 못하므로 프로세스가 완료된 후 스크롤 합니다. `.passive` 수식어는 이 이벤트가 기본 동작을 멈추지 않는다는 것을 브라우저에 알릴 수 있습니다.
 
-<p class="tip">`.passive`와 `.prevent`를 함께 사용하지 마세요. because `.prevent` will be ignored and your browser will probably show you a warning. Remember, `.passive` communicates to the browser that you _don't_ want to prevent the event's default behavior.</p>
+<p class="tip">`.passive`와 `.prevent`를 함께 사용하지 마세요. 왜냐하면 `.prevent`는 무시되고 브라우저에서 아마도 콘솔 경고를 보여줄 것이기 때문입니다. `.passive`는 이벤트의 기본 동작을 멈추지 _않는다_는 것을  브라우저에 알린다는 것을 명심하세요.</p>
 
 ## 키 수식어
 
@@ -240,15 +240,15 @@ Vue also offers the `.passive` modifier, corresponding to [`addEventListener`'s 
 
 ### Key Codes
 
-<p class="tip">The use of `keyCode` events [is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) and may not be supported in new browsers.</p>
+<p class="tip">`keyCode` 이벤트가 [더 이상 사용되지 않고](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) 새로운 브라우저에서 지원하지 않을 수도 있습니다.</p>
 
-Using `keyCode` attributes is also permitted:
+키 수식어 대신 `keyCode`를 사용하는 것도 가능합니다.
 
 ``` html
 <input v-on:keyup.13="submit">
 ```
 
-Vue provides aliases for the most commonly used key codes when necessary for legacy browser support:
+Vue는 기존 브라우저 지원이 필요할 때 가장 흔하게 사용되는 keyCode의 별칭을 제공합니다.
 
 - `.enter`
 - `.tab`
@@ -292,8 +292,7 @@ Vue.config.keyCodes.f1 = 112
 <div @click.ctrl="doSomething">Do something</div>
 ```
 
-<p class="tip">
-수식어 키는 일반 키와 다르며 `keyup` 이벤트와 함께 사용되면 이벤트가 발생할 때 수식어 키가 눌려있어야 합니다. 즉,`keyup.ctrl`는 `ctrl`을 누른 상태에서 키를 놓으면 트리거됩니다. `ctrl` 키만 놓으면 트리거되지 않습니다.
+<p class="tip">수식어 키는 일반 키와 다르며 `keyup` 이벤트와 함께 사용되면 이벤트가 발생할 때 수식어 키가 눌려있어야 합니다. 즉,`keyup.ctrl`는 `ctrl`을 누른 상태에서 키를 놓으면 트리거됩니다. `ctrl` 키만 놓으면 트리거되지 않습니다.
 </p>
 
 ### `.exact` 수식어

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -8,9 +8,7 @@ order: 10
 
 `v-model` 디렉티브를 사용하여 폼 input과 textarea 엘리먼트에 양방향 데이터 바인딩을 생성할 수 있습니다. 입력 유형에 따라 엘리먼트를 업데이트 하는 올바른 방법을 자동으로 선택합니다. 약간 이상하지만 `v-model`은 기본적으로 사용자 입력 이벤트에 대한 데이터를 업데이트하는 "syntax sugar"이며 일부 경우에 특별한 주의를 해야합니다.
 
-<p class="tip">
-`v-model`은 모든 form 엘리먼트의 초기 `value`와 `checked` 그리고 `selected` 속성을 무시합니다. 항상 Vue 인스턴스 데이터를 원본 소스로 취급합니다. 컴포넌트의 `data` 옵션 안에 있는 JavaScript에서 초기값을 선언해야합니다.
-</p>
+<p class="tip">`v-model`은 모든 form 엘리먼트의 초기 `value`와 `checked` 그리고 `selected` 속성을 무시합니다. 항상 Vue 인스턴스 데이터를 원본 소스로 취급합니다. 컴포넌트의 `data` 옵션 안에 있는 JavaScript에서 초기값을 선언해야합니다.</p>
 
 `v-model` internally uses different properties and emits different events for different input elements:
 - text and textarea elements use `value` property and `input` event;

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -290,7 +290,7 @@ Vue.set(vm.items, indexOfItem, newValue)
 vm.items.splice(indexOfItem, 1, newValue)
 ```
 
-You can also use the [`vm.$set`](https://vuejs.org/v2/api/#vm-set) instance method, which is an alias for the global `Vue.set`:
+인스턴스 메소드인 `vm.$set`를 사용할 수도 있습니다. 이는 전역 `Vue.set`의 별칭입니다:
 
 ``` js
 vm.$set(vm.items, indexOfItem, newValue)
@@ -439,7 +439,7 @@ methods: {
 
 ## `v-for` 와 `v-if`
 
-<p class="tip">Note that it's **not** recommended to use `v-if` and `v-for` together. Refer to [style guide](/v2/style-guide/#Avoid-v-if-with-v-for-essential) for details.</p>
+<p class="tip">`v-if` 와 `v-for`를 같이 사용하는 것은 **추천하지 않습니다.** 자세한 내용은 [스타일 가이드](/v2/style-guide/#Avoid-v-if-with-v-for-essential)를 참조하세요.</p>
 
 동일한 노드에 두가지 모두 있다면, `v-for`가 `v-if`보다 높은 우선순위를 갖습니다. 즉, `v-if`는 루프가 반복될 때마다 실행됩니다. 이는 *일부* 항목만 렌더링 하려는 경우 유용합니다.
 

--- a/src/v2/guide/mixins.md
+++ b/src/v2/guide/mixins.md
@@ -36,7 +36,7 @@ var component = new Component() // => "hello from mixin!"
 ## 옵션 병합
 mixin과 컴포넌트 자체에 중첩 옵션이 포함되어 있으면 적절한 전략을 사용하여 "병합"됩니다.
 
-For example, data objects undergo a recursive merge, with the component's data taking priority in cases of conflicts.
+예를 들어, 데이터 객체는 충돌이 발생했을 경우 컴포넌트의 데이터를 우선적으로 재귀적으로 병합합니다.
 
 ``` js
 var mixin = {

--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -123,15 +123,15 @@ Vue.component('example', {
 })
 ```
 
-Since `$nextTick()` returns a promise, you can achieve the same as the above using the new [ES2017 async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) syntax:
+`$nextTick()`이 promise를 반환하기 때문에, 새로운 [ES2017 async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)구문을 사용해서 위와 같은 결과를 얻을 수 있습니다.
 
 ``` js
   methods: {
     updateMessage: async function () {
       this.message = 'updated'
-      console.log(this.$el.textContent) // => 'not updated'
+      console.log(this.$el.textContent) // => '업데이트되지 않음'
       await this.$nextTick()
-      console.log(this.$el.textContent) // => 'updated'
+      console.log(this.$el.textContent) // => '업데이트됨'
     }
   }
 ```

--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -494,7 +494,7 @@ new Vue({
 })
 ```
 
-<p class="tip">`createElement`를 별칭 `h`로 이용하는 것은 Vue 생태계에서 볼 수 있는 공통된 관습이며 실제로 JSX에 필요합니다.  Starting with [version 3.4.0](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) of the Babel plugin for Vue, we automatically inject `const h = this.$createElement` in any method and getter (not functions or arrow functions), declared in ES2015 syntax that has JSX, so you can drop the `(h)` parameter. With prior versions of the plugin, your app would throw an error if `h` was not available in the scope. 사용하는 범위에서 `h`를 사용할 수 없다면, 앱은 오류를 발생시킵니다.</p>
+<p class="tip">`createElement`를 별칭 `h`로 이용하는 것은 Vue 생태계에서 볼 수 있는 공통된 관습이며 실제로 JSX에 필요합니다.  Vue를 위한 Babel 플러그인을 3.4.0버전으로 시작한다면,  JSX가 포함된 ES2015 문법으로 선언된 모든 method와 getter(함수나 화살표함수가 아니라)에 자동으로 `const h = this.$createElement`를 넣기 때문에 `(h)`매개변수를 삭제할 수 있습니다. 플러그인이 이전버전이고 사용하는 범위에서 `h`를 사용할 수 없다면, 앱은 오류를 발생시킵니다.</p>
 
 JSX가 JavaScript에 매핑되는 방법에 대한 [자세한 내용](https://github.com/vuejs/jsx#installation)을 확인하세요.
 
@@ -584,23 +584,23 @@ Vue.component('smart-list', {
 
 ### 자식 요소/컴포넌트에 속성과 이벤트 전달하기
 
-On normal components, attributes not defined as props are automatically added to the root element of the component, replacing or [intelligently merging with](class-and-style.html) any existing attributes of the same name.
+평범한 컴포넌트에서 props로 정의되지 않은 속성은 같은 이름의 기존 속성으로 대체되거나 지능적으로 병합해서 컴포넌트의 루트 엘리먼트에 자동으로 추가됩니다.
 
-Functional components, however, require you to explicitly define this behavior:
+하지만 함수형 컴포넌트는 이 행동을 명시적으로 정의하는 것을 필요로 합니다.
 
 ```js
 Vue.component('my-functional-button', {
   functional: true,
   render: function (createElement, context) {
-    // Transparently pass any attributes, event listeners, children, etc.
+    // 모든 속성, 이벤트 리스너, children 등을 명백하게 전달한다.
     return createElement('button', context.data, context.children)
   }
 })
 ```
 
-By passing `context.data` as the second argument to `createElement`, we are passing down any attributes or event listeners used on `my-functional-button`. It's so transparent, in fact, that events don't even require the `.native` modifier.
+`createElement`의 두번째 인자로 `context.data`를 전달함으로써, `my-functional-button`에 사용된 모든 속성이나 이벤트 리스너를 전달할 수 있습니다. 사실, 이는 명백해서 이벤트도 심지어 `.native`수식어를 요구하지 않습니다.
 
-If you are using template-based functional components, you will also have to manually add attributes and listeners. Since we have access to the individual context contents, we can use `data.attrs` to pass along any HTML attributes and `listeners` _(the alias for `data.on`)_ to pass along any event listeners.
+만약 template 기반 함수형 컴포넌트를 사용한다면 수동으로 속성과 리스너를 추가해야 합니다. 각각의 context 내용에 접근할 수있으므로 HTML 속성을 전달하기 위해 `data.attrs`를 사용하고 이벤트 리스너를 전달하기 위해 (`data.on`의 별칭인)`listeners`를 사용할 수 있다.
 
 ```html
 <template functional>

--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -71,6 +71,6 @@ order: 401
 
 ### 고급 사용자를 위한 내용
 
-The CLI takes care of most of the tooling configurations for you, but also allows fine-grained customization through its own [config options](https://cli.vuejs.org/config/).
+CLI는 도구의 설정의 대부분을 관리하지만, 자체 [설정 옵션](https://cli.vuejs.org/config/)을 통해 세밀한 사용자 정의또한 허용합니다.
 
-In case you prefer setting up your own build setup from scratch, you will need to manually configure webpack with [vue-loader](https://vue-loader.vuejs.org). To learn more about webpack itself, check out [their official docs](https://webpack.js.org/configuration/) and [Webpack Academy](https://webpack.academy/p/the-core-concepts).
+처음부터 자신만의 빌드 설정을 설정하는 것을 선호한다면, [vue-loader](https://vue-loader.vuejs.org)와 Webpack을 수동적으로 구성해야 합니다.  Webpack 자체에 대해 더 배우기를 원한다면 [공식문서](https://webpack.js.org/configuration/)나 [Webpack Academy](https://webpack.academy/p/the-core-concepts)를 확인하세요.

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -33,14 +33,14 @@ Mustache 태그는 해당 데이터 객체의 `msg` 속성 값으로 대체됩�
 이중 중괄호(mustaches)는 HTML이 아닌 일반 텍스트로 데이터를 해석합니다. 실제 HTML을 출력하려면 `v-html` 디렉티브를 사용해야 합니다.
 
 ``` html
-<p>Using mustaches: {{ rawHtml }}</p>
-<p>Using v-html directive: <span v-html="rawHtml"></span></p>
+<p>이중 중괄호 사용 시: {{ rawHtml }}</p>
+<p>v-html 디렉티브 사용 시: <span v-html="rawHtml"></span></p>
 ```
 
 {% raw %}
 <div id="example1" class="demo">
-  <p>Using mustaches: {{ rawHtml }}</p>
-  <p>Using v-html directive: <span v-html="rawHtml"></span></p>
+  <p>이중 중괄호 사용 시: {{ rawHtml }}</p>
+  <p>v-html 디렉티브 사용 시: <span v-html="rawHtml"></span></p>
 </div>
 <script>
 new Vue({

--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -954,9 +954,9 @@ new Vue({
 그렇다면`v-for`를 사용하여 동시에 렌더링 하고자 하는 항목의 전체 목록이 있는 경우는 어떨까요? 이 경우 우리는`<transition-group>` 컴포넌트를 사용합니다. 예를 들어보기 전에 이 컴포넌트에 대해 알아야 할 몇 가지 중요한 사항이 있습니다.
 
 - `<transition>` 과 달리, 실제 요소인 `<span>`을 렌더링합니다. `tag` 속성으로 렌더링 된 요소를 변경할 수 있습니다.
-- [Transition modes](#Transition-Modes) are not available, because we are no longer alternating between mutually exclusive elements.
+- [트랜지션 모드](#트랜지션-모드)는 사용할 수 없습니다. 왜냐하면 더이상 상호 배타적인 요소가 번갈아 나오지 않기 때문입니다.
 - 엘리먼트의 내부 구현은 **항상 필요합니다** 고유한 `key` 속성을 갖습니다
-- CSS transition classes will be applied to inner elements and not to the group/container itself.
+- CSS 트랜지션 클래스들은 내부 요소들에 적용되고 그룹/container 자체에 적용되지 않습니다.
 
 ### 리스트의 진입 / 진출 트랜지션
 


### PR DESCRIPTION
- enter이 부자연스럽게 들어간 곳을 없앴습니다.
- 부분적으로 번역이 되지 않은 부분을 번역했습니다.
  - 사용자 지정 디렉티브
  - 템플릿 문법
  - 이벤트 핸들링
  - 폼 입력 바인딩
  - 리스트 렌더링
  - 믹스인
  - Render Functions & JSX
  - 싱글파일 컴포넌트
  - 반응형에 대해 깊게 알아보기
  - 진입/진출 그리고 리스트 트랜지션
- 중복되는 Heading을 삭제했습니다.
  - 클래스와 스타일 바인딩에서 'HTML 클래스 바인딩하기'가 중복되어 삭제했습니다.