### PR TITLE
Translation Updated: Straggering transition

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -1304,9 +1304,9 @@ new Vue({
 </style>
 {% endraw %}
 
-### 비틀거리는 목록 트랜지션
+### 지연된 목록 트랜지션
 
-데이터 속성을 통해 JavaScript 트랜지션과 통신함으로써 목록에서 트랜지션을 비틀 수 있습니다.
+JavaScript 트랜지션과 통신함으로써 목록 내 각 항목의 데이터 속성을 이용해 트랜지션을 지연되도록 할 수 있습니다.
 
 ``` html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js"></script>

--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -1304,9 +1304,9 @@ new Vue({
 </style>
 {% endraw %}
 
-### 지연된 목록 트랜지션
+### 스태거링 목록 트랜지션
 
-JavaScript 트랜지션과 통신함으로써 목록 내 각 항목의 데이터 속성을 이용해 트랜지션을 지연되도록 할 수 있습니다.
+JavaScript 트랜지션과 통신함으로써 목록 내 각 항목의 데이터 속성을 이용해 트랜지션을 스태거(stagger) 되도록 할 수 있습니다.
 
 ``` html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js"></script>


### PR DESCRIPTION
기존에 **_비틀거리는_** 트랜지션으로 번역된 항목이 있었습니다.

**_비틀거리는_** 이라는 단어의 원문은 **_Staggering_** 이며, 사전적인 의미로써 첫 번째로 오는 단어는 **_비틀거리는_** 이 맞습니다. 하지만 문맥상으로 해당 단어의 다른 뜻인 **_망설이는, 지연된_** 정도의의 뜻이 문단을 이해하는데 좋지 않을까 하여 PR을 작성하였습니다.

![image](https://user-images.githubusercontent.com/44422495/75518232-cb662880-5a43-11ea-8432-ce3158ddd44f.png)
