### PR TITLE
'두 컴포넌트 사이의 순환 참조' 중 - 오타 교정

### DIFF
--- a/src/v2/guide/components-edge-cases.md
+++ b/src/v2/guide/components-edge-cases.md
@@ -272,7 +272,7 @@ template: '<div><stack-overflow></stack-overflow></div>'
 
 ### 두 컴포넌트 사이의 순환 참조
 
-Finder나 File Explorer 같은 파일 디렉토리 트리를 만드는 경우를 생각해 봅시다. 아마 아래와 같은 `tree-foler` 컴포넌트를 만들었을 것입니다:
+Finder나 File Explorer 같은 파일 디렉토리 트리를 만드는 경우를 생각해 봅시다. 아마 아래와 같은 `tree-folder` 컴포넌트를 만들었을 것입니다:
 
 ``` html
 <p>


### PR DESCRIPTION
안녕하세요, 재귀 컴포넌트 내용을 보고 있던 중 사소한 오타를 발견해 제보드립니다.

**원본**
![image](https://user-images.githubusercontent.com/26535030/119341647-013d9f80-bccf-11eb-8ed1-1502e8354d8d.png)

**번역분**
![image](https://user-images.githubusercontent.com/26535030/119341438-b7ed5000-bcce-11eb-87bb-03579d1239a4.png)

아마 번역해주시는 과정에서 사소한 오타가 있던 것 같아요 :)